### PR TITLE
adds insightsv3 api support (basic)

### DIFF
--- a/integration_tests/insightsv3_integration_test.go
+++ b/integration_tests/insightsv3_integration_test.go
@@ -1,0 +1,45 @@
+package integration_tests
+
+import (
+	. "github.com/smartystreets/goconvey/convey"
+	"testing"
+	. "github.com/talbright/go-desk/types"
+	"time"
+)
+
+func TestInsightsV3Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration tests are skipping in short mode")
+	}
+	client := CreateClient()
+
+	Convey("should be able to run report", t, func() {
+		query := NewInsightsV3Query()
+		query.Dimension1 = "action_agent"
+		query.Fields = []string{"case_reopens", "resolved_cases", "inbound_interactions"}
+		// view 10 week period
+		query.Time.Min = Timestamp{time.Now().Add(-10 * 7 * 24 * time.Hour).UTC()}
+		query.Time.Max = Timestamp{time.Now().UTC()}
+		query.Time.WindowSize = "hour"
+
+		report, resp, err := client.InsightsV3.Report(query)
+
+		data := report.GetData()
+
+		// can only look at the results if we got a response
+		if len(data) > 0 {
+			r := data[0]
+
+			// check that the values were returned
+			for _, field := range report.Request.Fields {
+				if _, ok := r[field]; !ok {
+					t.Error("field ", field, " was not found in response")
+				}
+			}
+		}
+
+		So(err, ShouldBeNil)
+		So(resp.StatusCode, ShouldEqual, 200)
+	})
+}
+

--- a/integration_tests/insightsv3_integration_test.go
+++ b/integration_tests/insightsv3_integration_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	. "github.com/talbright/go-desk/types"
 	"time"
+	"strconv"
+	"sync"
 )
 
 func TestInsightsV3Integration(t *testing.T) {
@@ -24,20 +26,109 @@ func TestInsightsV3Integration(t *testing.T) {
 
 		report, resp, err := client.InsightsV3.Report(query)
 
-		data := report.GetData()
-
 		// can only look at the results if we got a response
-		if len(data) > 0 {
-			r := data[0]
+		if len(report.Data) > 0 {
+			r := report.Data[0]
 
 			// check that the values were returned
 			for _, field := range report.Request.Fields {
-				if _, ok := r[field]; !ok {
+				if _, ok := r.Data[field]; !ok {
 					t.Error("field ", field, " was not found in response")
 				}
 			}
 		}
 
+		So(err, ShouldBeNil)
+		So(resp.StatusCode, ShouldEqual, 200)
+	})
+
+	Convey("report should run when rate-limited", t, func() {
+		// exhaust the rate limit
+		_, resp, _ := client.Case.Get("1")
+		wait := sync.WaitGroup{}
+		// get the remaining amount of requests that are available from the API
+		ratelimit := resp.Header.Get("X-Rate-Limit-Remaining")
+		limit, _ := strconv.Atoi(ratelimit)
+		cases := 0
+
+		// send the number of requests remaining plus 10, seems like sometimes the
+		// Desk API will let you pass the rate limit threshold
+		for i := 0; i < limit + 10; i++ {
+			wait.Add(1)
+			go func(){
+				// issue a request against the API
+				// this request will block when the api limit has been hit
+				_, resp, _ := client.Case.Get("1")
+
+				// test that we had a successful response
+				if resp.StatusCode == 200 {
+					cases++
+				}
+
+				wait.Done()
+			}()
+		}
+
+		query := NewInsightsV3Query()
+		query.Dimension1 = "action_agent"
+		query.Fields = []string{"case_reopens", "resolved_cases", "inbound_interactions"}
+		// view 10 week period
+		query.Time.Min = Timestamp{time.Now().Add(-10 * 7 * 24 * time.Hour).UTC()}
+		query.Time.Max = Timestamp{time.Now().UTC()}
+		query.Time.WindowSize = "hour"
+
+		// at this point the request should be rate-limited, but should still complete
+		report, resp, err := client.InsightsV3.Report(query)
+
+		// can only look at the results if we got a response
+		if len(report.Data) > 0 {
+			r := report.Data[0]
+
+			// check that the values were returned
+			for _, field := range report.Request.Fields {
+				if _, ok := r.Data[field]; !ok {
+					t.Error("field ", field, " was not found in response")
+				}
+			}
+		}
+
+		// wait until all the requests have completed
+		wait.Wait()
+		So(err, ShouldBeNil)
+		So(resp.StatusCode, ShouldEqual, 200)
+	})
+
+	Convey("should handle two report requests", t, func(){
+		wait := sync.WaitGroup{}
+
+		query := NewInsightsV3Query()
+		query.Dimension1 = "action_agent"
+		query.Fields = []string{"case_reopens", "resolved_cases", "inbound_interactions"}
+		// view 10 week period
+		query.Time.Min = Timestamp{time.Now().Add(-10 * 7 * 24 * time.Hour).UTC()}
+		query.Time.Max = Timestamp{time.Now().UTC()}
+		query.Time.WindowSize = "hour"
+
+		// send the first request
+		client.InsightsV3.Report(query)
+		// only worry about the second request
+		report, resp, err := client.InsightsV3.Report(query)
+
+
+		// can only look at the results if we got a response
+		if len(report.Data) > 0 {
+			r := report.Data[0]
+
+			// check that the values were returned
+			for _, field := range report.Request.Fields {
+				if _, ok := r.Data[field]; !ok {
+					t.Error("field ", field, " was not found in response")
+				}
+			}
+		}
+
+		// wait until all the requests have completed
+		wait.Wait()
 		So(err, ShouldBeNil)
 		So(resp.StatusCode, ShouldEqual, 200)
 	})

--- a/resource/report.go
+++ b/resource/report.go
@@ -2,27 +2,51 @@ package resource
 
 import (
 	. "github.com/talbright/go-desk/types"
+	"time"
 )
 
-
 type InsightsV3Report struct {
-	Request *InsightsV3Query `json:"request"`
-	Header  []string         `json:"header"`
-	Data    [][]interface{}  `json:"data"`
+	Request *InsightsV3Query        `json:"request"`
+	Header  []string                `json:"header"`
+	RawData [][]interface{}         `json:"data"`
+	Data    []*InsightsV3ReportItem
 }
 
-func (r *InsightsV3Report) GetData() []map[string] interface{} {
-	data := []map[string] interface{}{}
+type InsightsV3ReportItem struct {
+	Dimension1Value interface{}
+	Dimension2Value interface{}
+	WindowTime      Timestamp
+	Data            map[string] interface{}
+}
 
-	for i, d := range r.Data {
+func (r *InsightsV3Report) Unravel() {
+	for _, d := range r.RawData {
 		// initialize the map
-		data = append(data, map[string] interface{}{})
+		item := InsightsV3ReportItem{
+			Data: make(map[string] interface{}),
+		}
 
-		// save all the values in the map using the header as the template
-		for j, header := range r.Header {
-			data[i][header] = d[j]
+		// check that the window time is given
+		if d[0] != nil {
+			time, err := time.Parse(time.RFC3339, d[0].(string))
+
+			if err == nil {
+				// add the window time as a timestamp type
+				item.WindowTime = Timestamp{time}
+			}
+		}
+
+		// dimension 1 value is always the second index
+		item.Dimension1Value = d[1]
+		// dimension 2 value is always the third index
+		item.Dimension2Value = d[2]
+
+		// need to grab a slice so the headers and data fields line up
+		headers := r.Header[3:]
+		// loop through the rest of the indexes and save the data to the items data field
+		for j, val := range d[3:] {
+			// use the headers value as the key in the map
+			item.Data[headers[j]] = val
 		}
 	}
-
-	return data
 }

--- a/resource/report.go
+++ b/resource/report.go
@@ -1,0 +1,28 @@
+package resource
+
+import (
+	. "github.com/talbright/go-desk/types"
+)
+
+
+type InsightsV3Report struct {
+	Request *InsightsV3Query `json:"request"`
+	Header  []string         `json:"header"`
+	Data    [][]interface{}  `json:"data"`
+}
+
+func (r *InsightsV3Report) GetData() []map[string] interface{} {
+	data := []map[string] interface{}{}
+
+	for i, d := range r.Data {
+		// initialize the map
+		data = append(data, map[string] interface{}{})
+
+		// save all the values in the map using the header as the template
+		for j, header := range r.Header {
+			data[i][header] = d[j]
+		}
+	}
+
+	return data
+}

--- a/resource/report.go
+++ b/resource/report.go
@@ -6,9 +6,9 @@ import (
 )
 
 type InsightsV3Report struct {
-	Request *InsightsV3Query        `json:"request"`
-	Header  []string                `json:"header"`
-	RawData [][]interface{}         `json:"data"`
+	Request *InsightsV3Query `json:"request"`
+	Header  []string         `json:"header"`
+	RawData [][]interface{}  `json:"data"`
 	Data    []*InsightsV3ReportItem
 }
 
@@ -16,19 +16,19 @@ type InsightsV3ReportItem struct {
 	Dimension1Value interface{}
 	Dimension2Value interface{}
 	WindowTime      Timestamp
-	Data            map[string] interface{}
+	Data            map[string]interface{}
 }
 
 func (r *InsightsV3Report) Unravel() {
 	for _, d := range r.RawData {
 		// initialize the map
-		item := InsightsV3ReportItem{
-			Data: make(map[string] interface{}),
+		item := &InsightsV3ReportItem{
+			Data: make(map[string]interface{}),
 		}
 
 		// check that the window time is given
 		if d[0] != nil {
-			time, err := time.Parse(time.RFC3339, d[0].(string))
+			time, err := time.Parse("2006-01-02 15:04:05", d[0].(string))
 
 			if err == nil {
 				// add the window time as a timestamp type
@@ -48,5 +48,7 @@ func (r *InsightsV3Report) Unravel() {
 			// use the headers value as the key in the map
 			item.Data[headers[j]] = val
 		}
+
+		r.Data = append(r.Data, item)
 	}
 }

--- a/resource/report_test.go
+++ b/resource/report_test.go
@@ -1,0 +1,7 @@
+package resource
+
+import "testing"
+
+func TestReport(t *testing.T) {
+
+}

--- a/service/client.go
+++ b/service/client.go
@@ -24,6 +24,7 @@ type Client struct {
 	Company      *CompanyService
 	User         *UserService
 	Group        *GroupService
+	InsightsV3   *InsightsV3Service
 }
 
 func NewClient(httpClient *http.Client, endpointURL string, userEmail string, userPassword string) *Client {
@@ -37,6 +38,7 @@ func NewClient(httpClient *http.Client, endpointURL string, userEmail string, us
 	c.Company = &CompanyService{client: c}
 	c.User = &UserService{client: c}
 	c.Group = &GroupService{client: c}
+	c.InsightsV3 = &InsightsV3Service{client: c}
 	return c
 }
 

--- a/service/group_service.go
+++ b/service/group_service.go
@@ -30,6 +30,25 @@ func (c *GroupService) Get(id string) (*Group, *http.Response, error) {
 	return group, resp, err
 }
 
+func (c *GroupService) GetUserGroups(id string) (*Page, *http.Response, error) {
+	restful := Restful{}
+	page := new(Page)
+	resp, err := restful.
+		Get("/api/v2/users/"+id+"/groups").
+		Json(page).
+		Client(c.client).
+		Do()
+
+	if err != nil {
+		return nil, resp, err
+	}
+	err = c.unravelPage(page)
+	if err != nil {
+		return nil, nil, err
+	}
+	return page, resp, err
+}
+
 // List group with filtering and pagination.
 // See Desk API: http://dev.desk.com/API/groups/#list
 func (c *GroupService) List(params *url.Values) (*Page, *http.Response, error) {

--- a/service/insights_v3.go
+++ b/service/insights_v3.go
@@ -19,6 +19,7 @@ func (s *InsightsV3Service) Report(query *InsightsV3Query) (*InsightsV3Report, *
 		Json(report).
 		Client(s.client).
 		Do()
+	report.Unravel()
 
 	return report, resp, err
 }

--- a/service/insights_v3.go
+++ b/service/insights_v3.go
@@ -1,0 +1,24 @@
+package service
+
+import (
+	. "github.com/talbright/go-desk/types"
+	. "github.com/talbright/go-desk/resource"
+	"net/http"
+)
+
+type InsightsV3Service struct {
+	client *Client
+}
+
+func (s *InsightsV3Service) Report(query *InsightsV3Query) (*InsightsV3Report, *http.Response, error) {
+	restful := Restful{}
+	report := &InsightsV3Report{}
+	resp, err := restful.
+		Post("insights3/reports").
+		Body(query).
+		Json(report).
+		Client(s.client).
+		Do()
+
+	return report, resp, err
+}

--- a/types/insights_v3_filter.go
+++ b/types/insights_v3_filter.go
@@ -1,0 +1,99 @@
+//
+// Copyright (c) 2015 Highwinds Network Group, inc.
+// Unauthorized copying of this file, via any medium is strictly prohibited
+// Proprietary and confidential.
+//
+// @author    Scot Wells <scot.wells@highwinds.com>
+// @copyright 2015 Highwinds Network Group, inc.
+//
+package types
+
+import (
+	"encoding/json"
+)
+
+const (
+	TYPE_INCLUDE = "Include"
+	TYPE_EXCLUDE = "Exclude"
+
+	// there's more fields available but they're currently undocumented...
+	FIELD_CUSTOM_FIELDS = "Custom Fields"
+	FIELD_LABELS        = "Labels"
+)
+
+type InsightsV3Filter struct {
+	Type    string
+	Field   string
+	Filters []map[string]interface{}
+}
+
+func NewInsightsV3Filter() *InsightsV3Filter {
+	return &InsightsV3Filter{
+		Filters: []map[string]interface{}{},
+	}
+}
+
+func (f *InsightsV3Filter) AddFilter(filter map[string]interface{}) {
+	f.Filters = append(f.Filters, filter)
+}
+
+func (f *InsightsV3Filter) MarshalJSON() ([]byte, error) {
+	data := [6]interface{}{}
+
+	data[0] = f.Type
+	data[1] = f.Field
+	// this field is currently undocumented by Desk...
+	// had to look at the request sent out by the Business Insights
+	// dashboard just to get this to work properly
+	data[2] = "Is"
+	// same here...
+	data[3] = ""
+	data[4] = false
+	data[5] = f.Filters
+
+	j, err := json.Marshal(data)
+
+	return j, err
+}
+
+type InsightsV3FilterGroup struct {
+	Filters []*InsightsV3Filter
+}
+
+func NewInsightsV3FilterGroup() *InsightsV3FilterGroup {
+	return &InsightsV3FilterGroup{}
+}
+
+func (g *InsightsV3FilterGroup) Add(filter *InsightsV3Filter) {
+	g.Filters = append(g.Filters, filter)
+}
+
+func (f *InsightsV3FilterGroup) MarshalJSON() ([]byte, error) {
+	j, err := json.Marshal(f.Filters)
+	return j, err
+}
+
+// implements the Unmarshaler interface so when trying to parse the response it can
+// be turned back into a filter struct
+func (f *InsightsV3FilterGroup) UnmarshalJSON(d []byte) error {
+	data := [][]interface{}{}
+
+	err := json.Unmarshal(d, &data)
+
+	if err != nil {
+		return err
+	}
+
+	for _, f := range data {
+		filter := NewInsightsV3Filter()
+
+		filter.Type = f[0].(string)
+		filter.Field = f[1].(string)
+
+		for _, field := range f[5].([]interface{}) {
+			filter.AddFilter(field.(map[string]interface{}))
+		}
+	}
+
+	return nil
+}

--- a/types/insights_v3_filter_test.go
+++ b/types/insights_v3_filter_test.go
@@ -1,0 +1,53 @@
+//
+// Copyright (c) 2015 Highwinds Network Group, inc.
+// Unauthorized copying of this file, via any medium is strictly prohibited
+// Proprietary and confidential.
+//
+// @author    Scot Wells <scot.wells@highwinds.com>
+// @copyright 2015 Highwinds Network Group, inc.
+//
+package types_test
+import (
+	"testing"
+	"github.com/talbright/go-desk/types"
+	. "github.com/smartystreets/goconvey/convey"
+	"encoding/json"
+)
+
+func TestFilter(t *testing.T) {
+	filter := types.NewInsightsV3Filter()
+
+	Convey("TestFilter", t, func() {
+		Convey("test correct json output", func() {
+			filter.Type = types.TYPE_EXCLUDE
+			filter.Field = types.FIELD_LABELS
+
+			json, err := json.Marshal(filter)
+		})
+	})
+}
+
+func TestFilterGroup(t *testing.T) {
+	group := types.NewInsightsV3FilterGroup()
+
+	Convey("TestFilterGroup", t, func() {
+		Convey("Test add filter", func() {
+			So(len(group.Filters), ShouldEqual, 0)
+			filter := types.NewInsightsV3Filter()
+			filter.Field = "Custom Fields"
+			filter.Type = "Include"
+
+			group.Add(filter)
+			So(len(group.Filters), ShouldEqual, 1)
+
+			j, err := group.MarshalJSON()
+
+			So(err, ShouldBeNil)
+			So(j, ShouldNotBeNil)
+
+			json := string(j)
+			So(json, ShouldContainSubstring, "Custom Fields")
+			So(json, ShouldContainSubstring, "Include")
+		})
+	})
+}

--- a/types/insights_v3_query.go
+++ b/types/insights_v3_query.go
@@ -1,38 +1,99 @@
 package types
 
-import "errors"
-
-var (
-	invalidWindowSize = errors.New("Invalid window size")
+import (
+	"encoding/json"
 )
 
+// allows easy creation of an insights query for the Desk Reporting API
 type InsightsV3Query struct {
-	Fields           []string        `json:"fields,omitempty"`
-	Dimension1       string          `json:"dimension1,omitempty"`
-	Dimension1Values interface{}     `json:"dimension1_values,omitempty"`
-	Dimension2       string          `json:"dimension2,omitempty"`
-	Dimension2Values interface{}     `json:"dimension2_values,omitempty"`
-	Time             *InsightsV3Time `json:"time"`
+	Fields           []string                 `json:"fields,omitempty"`
+	Dimension1       string                   `json:"dimension1,omitempty"`
+	Dimension1Values interface{}              `json:"dimension1_values,omitempty"`
+	Dimension2       string                   `json:"dimension2,omitempty"`
+	Dimension2Values interface{}              `json:"dimension2_values,omitempty"`
+	Time             *InsightsV3Time          `json:"time"`
+	Filters          []*InsightsV3FilterGroup `json:"filters,omitempty"`
+	// keeping a map of all the fields allows us quickly check if the
+	// field was already added or not, otherwise we'd have to loop through
+	// the entire array of fields to make sure it is unique
+	fieldMap map[string]bool
 }
 
+// create a new insights query
 func NewInsightsV3Query() *InsightsV3Query {
 	return &InsightsV3Query{
-		Time: &InsightsV3Time{},
+		Time:     NewInsightsV3Time(),
+		fieldMap: map[string]bool{},
+		Filters:  []*InsightsV3FilterGroup{},
+		Fields:   []string{},
 	}
 }
 
-type InsightsV3Time struct {
-	Min        Timestamp `json:"min"`
-	Max        Timestamp `json:"max"`
-	WindowSize string    `json:"window_size"`
-}
-
-func (t *InsightsV3Time) SetWindowSize(size string) error {
-	switch size {
-	case "none", "hour", "day", "week", "month":
-		t.WindowSize = size
-		return nil
+// adds a single field to the query
+func (q *InsightsV3Query) AddField(field string) *InsightsV3Query {
+	if _, ok := q.fieldMap[field]; !ok {
+		// append the field to the query
+		q.Fields = append(q.Fields, field)
+		// marks that the field has been added so we know items are unique
+		q.fieldMap[field] = true
 	}
 
-	return invalidWindowSize
+	return q
+}
+
+// add multiple fields to the query
+func (q *InsightsV3Query) AddFields(fields []string) *InsightsV3Query {
+	for _, field := range fields {
+		// pass each field on to the add field function
+		q.AddField(field)
+	}
+
+	return q
+}
+
+func (q *InsightsV3Query) SetReportTime(time *InsightsV3Time) *InsightsV3Query {
+	q.Time = time
+
+	return q
+}
+
+func (q *InsightsV3Query) SetDimension1(dimension string) *InsightsV3Query {
+	q.Dimension1 = dimension
+
+	return q
+}
+
+func (q *InsightsV3Query) SetDimension1Values(value interface{}) *InsightsV3Query {
+	q.Dimension1Values = value
+
+	return q
+}
+
+func (q *InsightsV3Query) SetDimension2(dimension string) *InsightsV3Query {
+	q.Dimension2 = dimension
+
+	return q
+}
+
+func (q *InsightsV3Query) SetDimension2Values(value interface{}) *InsightsV3Query {
+	q.Dimension2Values = value
+
+	return q
+}
+
+// add a filter to the query
+func (q *InsightsV3Query) AddFilters(filters *InsightsV3FilterGroup) *InsightsV3Query {
+	q.Filters = append(q.Filters, filters)
+
+	return q
+}
+
+func (t *InsightsV3Query) String() string {
+	j, err := json.Marshal(t)
+
+	if err != nil {
+		return ""
+	}
+
+	return string(j)
 }

--- a/types/insights_v3_query.go
+++ b/types/insights_v3_query.go
@@ -1,0 +1,38 @@
+package types
+
+import "errors"
+
+var (
+	invalidWindowSize = errors.New("Invalid window size")
+)
+
+type InsightsV3Query struct {
+	Fields           []string        `json:"fields,omitempty"`
+	Dimension1       string          `json:"dimension1,omitempty"`
+	Dimension1Values interface{}     `json:"dimension1_values,omitempty"`
+	Dimension2       string          `json:"dimension2,omitempty"`
+	Dimension2Values interface{}     `json:"dimension2_values,omitempty"`
+	Time             *InsightsV3Time `json:"time"`
+}
+
+func NewInsightsV3Query() *InsightsV3Query {
+	return &InsightsV3Query{
+		Time: &InsightsV3Time{},
+	}
+}
+
+type InsightsV3Time struct {
+	Min        Timestamp `json:"min"`
+	Max        Timestamp `json:"max"`
+	WindowSize string    `json:"window_size"`
+}
+
+func (t *InsightsV3Time) SetWindowSize(size string) error {
+	switch size {
+	case "none", "hour", "day", "week", "month":
+		t.WindowSize = size
+		return nil
+	}
+
+	return invalidWindowSize
+}

--- a/types/insights_v3_query_test.go
+++ b/types/insights_v3_query_test.go
@@ -1,0 +1,108 @@
+package types_test
+
+import (
+	. "github.com/smartystreets/goconvey/convey"
+	"github.com/talbright/go-desk/types"
+	"testing"
+)
+
+func TestFields(t *testing.T) {
+	query := types.NewInsightsV3Query()
+
+	Convey("SetFieldsCorrectly", t, func() {
+		Convey("Should set single field correctly", func() {
+			query.AddField("testField")
+
+			// we've only added a single field
+			So(len(query.Fields), ShouldEqual, 1)
+		})
+
+		Convey("Should set multiple fields correctly", func() {
+			query.AddFields([]string{"test1", "test2"})
+
+			// added a single field before, now adding another two.. 1 + 2 = 3 :)
+			So(len(query.Fields), ShouldEqual, 3)
+		})
+
+		Convey("Shouldn't allow duplicates", func() {
+			query.AddField("test2")
+
+			So(len(query.Fields), ShouldEqual, 3)
+		})
+		Convey("Should convert to JSON properly", func() {
+			json := query.String()
+
+			// test that the json got generated correctly
+			So(json, ShouldContainSubstring, `"fields":["testField","test1","test2"]`)
+		})
+	})
+}
+
+func TestTimeSet(t *testing.T) {
+	query := types.NewInsightsV3Query()
+
+	Convey("SetTimeCorrectly", t, func() {
+		Convey("Be able to set the time", func() {
+			time := types.NewInsightsV3Time()
+
+			time.WindowSize = "hour"
+
+			query.SetReportTime(time)
+
+			So(query.Time.WindowSize, ShouldEqual, "hour")
+		})
+	})
+}
+
+func TestDimensions(t *testing.T) {
+	query := types.NewInsightsV3Query()
+
+	Convey("WorkWithDimensions", t, func() {
+		Convey("Be able to set Dimension1", func() {
+			query.SetDimension1("action_agent")
+
+			So(query.Dimension1, ShouldEqual, "action_agent")
+		})
+
+		Convey("Should be able to set Dimension1Value", func() {
+			query.SetDimension1Values("test")
+
+			So(query.Dimension1Values, ShouldEqual, "test")
+		})
+
+		Convey("Should be able to set Dimension2", func() {
+			query.SetDimension2("test2")
+
+			So(query.Dimension2, ShouldEqual, "test2")
+		})
+
+		Convey("Should be able to set Dimension2Values", func() {
+			query.SetDimension2Values("test3")
+
+			So(query.Dimension2Values, ShouldEqual, "test3")
+		})
+
+		Convey("Should convert to JSON correctly", func() {
+			json := query.String()
+
+			So(json, ShouldContainSubstring, `"dimension1":"action_agent"`)
+			So(json, ShouldContainSubstring, `"dimension1_values":"test"`)
+			So(json, ShouldContainSubstring, `"dimension2":"test2"`)
+			So(json, ShouldContainSubstring, `"dimension2_values":"test3"`)
+		})
+	})
+}
+
+func TestFilters(t *testing.T) {
+	query := types.NewInsightsV3Query()
+
+	Convey("QueryFilters", t, func() {
+		Convey("Add a filter group", func() {
+			query.AddFilters(types.NewInsightsV3FilterGroup())
+			So(len(query.Filters), ShouldEqual, 1)
+
+			query.AddFilters(types.NewInsightsV3FilterGroup())
+			So(len(query.Filters), ShouldEqual, 2)
+		})
+	})
+}

--- a/types/insights_v3_time.go
+++ b/types/insights_v3_time.go
@@ -1,0 +1,31 @@
+package types
+
+import (
+	"errors"
+)
+
+var (
+	invalidWindowSize = errors.New("Invalid window size")
+)
+
+type InsightsV3Time struct {
+	Min        Timestamp `json:"min"`
+	Max        Timestamp `json:"max"`
+	WindowSize string    `json:"window_size"`
+}
+
+func NewInsightsV3Time() *InsightsV3Time {
+	return &InsightsV3Time{
+		WindowSize: "none",
+	}
+}
+
+func (t *InsightsV3Time) SetWindowSize(size string) error {
+	switch size {
+	case "none", "hour", "day", "week", "month":
+		t.WindowSize = size
+		return nil
+	}
+
+	return invalidWindowSize
+}

--- a/types/insights_v3_time_test.go
+++ b/types/insights_v3_time_test.go
@@ -1,0 +1,34 @@
+package types_test
+
+import (
+	"testing"
+	"github.com/talbright/go-desk/types"
+	."github.com/smartystreets/goconvey/convey"
+	"encoding/json"
+)
+
+func TestTime(t *testing.T) {
+	time := types.NewInsightsV3Time()
+
+	Convey("WindowSize", t, func() {
+		Convey("Should set correctly", func() {
+			err := time.SetWindowSize("none")
+			So(err, ShouldBeNil)
+
+			err = time.SetWindowSize("invalid")
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("should convert to Json correctly", func() {
+			jsonBytes, err := json.Marshal(time)
+
+			json := string(jsonBytes)
+
+			So(err, ShouldBeNil)
+			So(json, ShouldContainSubstring, "min")
+			So(json, ShouldContainSubstring, "max")
+			So(json, ShouldContainSubstring, `"window_size":"none"`)
+		})
+	})
+
+}


### PR DESCRIPTION
Adds basic support of the insights v3 API. Basic usage below.

``` go
query := NewInsightsV3Query()
query.Dimension1 = "action_agent"
query.Fields = []string{"case_reopens", "resolved_cases", "inbound_interactions"}
// view 10 week period
query.Time.Min = Timestamp{time.Now().Add(-10 * 7 * 24 * time.Hour).UTC()}
query.Time.Max = Timestamp{time.Now().UTC()}
query.Time.WindowSize = "hour"

report, resp, err := client.InsightsV3.Report(query)
```

The `InsightsV3Query` struct is used to provide an easy interface to the [reports](http://dev.desk.com/API/insights3/#reports-create) query syntax. The `InsightsV3Report` struct has a function `GetData` that can be used to retrieve the data as a map where the key is the values corresponding key returned from `header`.
