### PR TITLE
fix issue where rate-limit retry would cause http error

### DIFF
--- a/service/client.go
+++ b/service/client.go
@@ -81,7 +81,9 @@ func (c *Client) Do(req *http.Request, v interface{}) (*http.Response, error) {
 	var resp *http.Response
 	var err error
 
+	body, err := ioutil.ReadAll(req.Body)
 	for {
+		req.Body = ioutil.NopCloser(bytes.NewBuffer(body))
 		resp, err = c.client.Do(req)
 
 		if err != nil {


### PR DESCRIPTION
After the client is rate-limited during a request with a body, on the second attempt, the http.Client will return an error `http: Request.ContentLength=687 with Body length 0`. This is caused by the io.Reader being exhausted on the first attempt. 

This fix reads the body of the request and then creates a new io.ReadCloser that the client can use with the request.
