### PR TITLE
fix ability to get class link

### DIFF
--- a/resource/hal.go
+++ b/resource/hal.go
@@ -71,7 +71,7 @@ func (c *Hal) AddHrefLink(class string, href string) {
 func (c *Hal) GetHrefLink(class string) string {
 	var href string
 	if c.HasLinkAndSubItem(class, "href") {
-		href = c.Links["self"]["href"].(string)
+		href = c.Links[class]["href"].(string)
 	}
 	return href
 }


### PR DESCRIPTION
The GetHrefLink function should return the href field from the link
map. It was hardcoded to return the href of the self class. It now
gets the href based on the given class variable
